### PR TITLE
Mqtt and wifi reconnection improvements

### DIFF
--- a/src/blecker.cpp
+++ b/src/blecker.cpp
@@ -30,6 +30,7 @@ Webhook webhook(rlog);
 // This signal will be emitted when we process characters
 // https://github.com/tomstewart89/Callback
 Signal<boolean> wifiStatusChanged;
+Signal<boolean> mqttStatusChanged;
 Signal<int> errorCodeChanged;
 Signal<String> messageArrived;
 Signal<MQTTMessage> mqttMessageSend;
@@ -52,9 +53,11 @@ void setup() {
   MethodSlot<Mqtt, boolean> wifiChangedForMqtt(&mqtt,&Mqtt::setConnected);
   MethodSlot<BlueTooth, boolean> wifiChangedForBluetooth(&blueTooth,&BlueTooth::setConnected);
   MethodSlot<Webservice, boolean> wifiChangedForWebservice(&webservice,&Webservice::setConnected);
+  MethodSlot<BlueTooth, boolean> mqttChangedForBluetooth(&blueTooth,&BlueTooth::setMqttConnected);
   wifiStatusChanged.attach(wifiChangedForMqtt);
   wifiStatusChanged.attach(wifiChangedForBluetooth);
   wifiStatusChanged.attach(wifiChangedForWebservice);
+  mqttStatusChanged.attach(mqttChangedForBluetooth);
   
   // Emit an error code for led
   MethodSlot<Led, int> errorCodeChangedForLed(&led,&Led::setMessage);
@@ -84,7 +87,7 @@ void setup() {
   webservice.setup(database);
   webhook.setup(database);
   
-  mqtt.setup(database, errorCodeChanged, messageArrived);
+  mqtt.setup(database, mqttStatusChanged, errorCodeChanged, messageArrived);
   // Connect to WiFi
   wifi.connectWifi();
 

--- a/src/bluetooth.h
+++ b/src/bluetooth.h
@@ -40,6 +40,8 @@ class BlueTooth: public BLEAdvertisedDeviceCallbacks {
     boolean detailedReport;
     boolean monitorObservedOnly; // Monitor devices only which are configured in the database
     boolean networkConnected; // Connected to the network (Wifi STA)
+    boolean mqttConnected; // Connected to MQTT server
+
 
     LinkedList<Device> devices;
     LinkedList<int> devicesToRemove;
@@ -49,6 +51,7 @@ class BlueTooth: public BLEAdvertisedDeviceCallbacks {
         void setup(Database &database, Signal<MQTTMessage> &mqttMessageSend, Signal<Device> &deviceChanged);
         void loop();
         void setConnected(boolean connected);
+        void setMqttConnected(boolean connected);
     
     private: 
         void onResult(BLEAdvertisedDevice advertisedDevice);

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -17,6 +17,7 @@ class Mqtt {
     Database* database;
     Signal<int>* errorCodeChanged;
     Signal<String>* mqttMessageArrived;
+    Signal<boolean>* mqttStatusChanged;
     String server;
     String user;
     String password;
@@ -31,6 +32,7 @@ class Mqtt {
     // MQTT connect try
     int lasttry;
     int maxtry;
+    int MQTTconnectTime;
 
     // Keepalive timeout
     int lastKeepAliveTime;
@@ -39,10 +41,11 @@ class Mqtt {
     boolean subscribed;
     boolean deviceStatusRetain;
     boolean lastiWillSet;
+    boolean mqtt_connected;
 
     public:
         Mqtt(Log& rlog);
-        void setup(Database &database, Signal<int> &errorCodeChanged, Signal<String> &mqttMessageArrived);
+        void setup(Database &database, Signal<boolean> &mqttStatusChanged, Signal<int> &errorCodeChanged, Signal<String> &mqttMessageArrived);
         void loop();
         void setConnected (boolean networkConnected);
         void sendMqttMessage(MQTTMessage message);

--- a/src/wifinetwork.cpp
+++ b/src/wifinetwork.cpp
@@ -3,6 +3,7 @@
 WifiNetwork::WifiNetwork(Log& rlog) : logger(rlog, "[WIFI]") {
     wifi_connected = false;
     tries = 0;
+    APstart = 0;
 }
 
 void WifiNetwork::setup(Database &database, Signal<boolean> &wifiStatusChanged, Signal<int> &errorCodeChanged, Signal<String> &ipAddressChanged){
@@ -56,6 +57,7 @@ void WifiNetwork::connectToAP() {
 void WifiNetwork::createAP() {
     configAP();
     WiFi.mode(WIFI_AP);
+    APstart = millis();
     logger << "AP is created from a function. Name: " << BOARD_NAME;
 }
 
@@ -163,6 +165,12 @@ void WifiNetwork::wifiConnectedLoop() {
 void WifiNetwork::wifiDisconnectedLoop() {
     // Try to reconnect time to time
     // TODO
+    if ((millis() - APstart) > (5 * 60 * 1000)) { // 5 min               
+        if (ssid.length() > 0) {
+           //this -> connectToAP();
+           ESP.restart();
+        }
+    }
 }
 
 void WifiNetwork::setupMDNS() {

--- a/src/wifinetwork.h
+++ b/src/wifinetwork.h
@@ -25,6 +25,7 @@ class WifiNetwork {
         String password;
 
         int tries;
+        int APstart;
         String uniqueBoardname;
 
         WifiNetwork(Log& rlog);


### PR DESCRIPTION
- Mqtt connection check and delay between reconnects added to avoid hammering mqtt server in loop
- Mqtt device status is retained to be available for devices connected to mqtt server after blecker boots up
- Last will is sent on mqtt server reconnect also
- ESP restarts after 5 minutes on wifi network downtime to repeat connection tries for unattended recovery after blackout
